### PR TITLE
Add initial main menu with Slate and UMG

### DIFF
--- a/Source/Defence/Defence.Build.cs
+++ b/Source/Defence/Defence.Build.cs
@@ -8,7 +8,7 @@ public class Defence : ModuleRules
 	{
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
-        PublicDependencyModuleNames.AddRange(new string[] {"Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput", "Niagara", "AIModule", "UMG"});
+        PublicDependencyModuleNames.AddRange(new string[] {"Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput", "Niagara", "AIModule", "UMG", "Slate", "SlateCore"});
 
     }
 }

--- a/Source/Defence/MainMenuWidget.cpp
+++ b/Source/Defence/MainMenuWidget.cpp
@@ -1,0 +1,17 @@
+#include "MainMenuWidget.h"
+#include "SMainMenuWidget.h"
+
+TSharedRef<SWidget> UMainMenuWidget::RebuildWidget()
+{
+    SlateWidget = SNew(SMainMenuWidget)
+        .OnStartClicked(BIND_UOBJECT_DELEGATE(FSimpleDelegate, OnStartClicked))
+        .OnQuitClicked(BIND_UOBJECT_DELEGATE(FSimpleDelegate, OnQuitClicked));
+
+    return SlateWidget.ToSharedRef();
+}
+
+void UMainMenuWidget::ReleaseSlateResources(bool bReleaseChildren)
+{
+    SlateWidget.Reset();
+    Super::ReleaseSlateResources(bReleaseChildren);
+}

--- a/Source/Defence/MainMenuWidget.h
+++ b/Source/Defence/MainMenuWidget.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "MainMenuWidget.generated.h"
+
+class SMainMenuWidget;
+
+/** UMG wrapper for the main menu */
+UCLASS()
+class UMainMenuWidget : public UUserWidget
+{
+    GENERATED_BODY()
+public:
+    FSimpleDelegate OnStartClicked;
+    FSimpleDelegate OnQuitClicked;
+
+protected:
+    virtual TSharedRef<SWidget> RebuildWidget() override;
+    virtual void ReleaseSlateResources(bool bReleaseChildren) override;
+
+private:
+    TSharedPtr<SMainMenuWidget> SlateWidget;
+};

--- a/Source/Defence/MenuGameMode.cpp
+++ b/Source/Defence/MenuGameMode.cpp
@@ -1,0 +1,39 @@
+#include "MenuGameMode.h"
+#include "MainMenuWidget.h"
+#include "Kismet/GameplayStatics.h"
+#include "Kismet/KismetSystemLibrary.h"
+
+AMenuGameMode::AMenuGameMode()
+{
+    // No pawn or controller by default
+    DefaultPawnClass = nullptr;
+    PlayerControllerClass = nullptr;
+}
+
+void AMenuGameMode::BeginPlay()
+{
+    Super::BeginPlay();
+
+    if (MainMenuWidgetClass)
+    {
+        MainMenuWidget = CreateWidget<UMainMenuWidget>(GetWorld(), MainMenuWidgetClass);
+        if (MainMenuWidget)
+        {
+            MainMenuWidget->AddToViewport();
+            MainMenuWidget->OnStartClicked.BindUObject(this, &AMenuGameMode::HandleStartClicked);
+            MainMenuWidget->OnQuitClicked.BindUObject(this, &AMenuGameMode::HandleQuitClicked);
+        }
+    }
+}
+
+void AMenuGameMode::HandleStartClicked()
+{
+    // Replace "GameMap" with your actual gameplay map
+    UGameplayStatics::OpenLevel(this, FName(TEXT("GameMap")));
+}
+
+void AMenuGameMode::HandleQuitClicked()
+{
+    APlayerController* PC = UGameplayStatics::GetPlayerController(this, 0);
+    UKismetSystemLibrary::QuitGame(this, PC, EQuitPreference::Quit, true);
+}

--- a/Source/Defence/MenuGameMode.h
+++ b/Source/Defence/MenuGameMode.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/GameModeBase.h"
+#include "MenuGameMode.generated.h"
+
+class UMainMenuWidget;
+
+/** Game mode used for the main menu */
+UCLASS()
+class AMenuGameMode : public AGameModeBase
+{
+    GENERATED_BODY()
+public:
+    AMenuGameMode();
+
+    virtual void BeginPlay() override;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category=UI)
+    TSubclassOf<UMainMenuWidget> MainMenuWidgetClass;
+
+private:
+    UPROPERTY()
+    UMainMenuWidget* MainMenuWidget;
+
+    UFUNCTION()
+    void HandleStartClicked();
+
+    UFUNCTION()
+    void HandleQuitClicked();
+};

--- a/Source/Defence/SMainMenuWidget.cpp
+++ b/Source/Defence/SMainMenuWidget.cpp
@@ -1,0 +1,50 @@
+#include "SMainMenuWidget.h"
+#include "SlateOptMacros.h"
+#include "Widgets/Layout/SVerticalBox.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Text/STextBlock.h"
+
+BEGIN_SLATE_FUNCTION_BUILD_OPTIMIZATION
+
+void SMainMenuWidget::Construct(const FArguments& InArgs)
+{
+    StartClicked = InArgs._OnStartClicked;
+    QuitClicked = InArgs._OnQuitClicked;
+
+    ChildSlot
+    [
+        SNew(SVerticalBox)
+        + SVerticalBox::Slot().AutoHeight().Padding(20)
+        [
+            SNew(SButton)
+            .Text(FText::FromString(TEXT("Start Game")))
+            .OnClicked(this, &SMainMenuWidget::HandleStartClicked)
+        ]
+        + SVerticalBox::Slot().AutoHeight().Padding(20)
+        [
+            SNew(SButton)
+            .Text(FText::FromString(TEXT("Quit")))
+            .OnClicked(this, &SMainMenuWidget::HandleQuitClicked)
+        ]
+    ];
+}
+
+FReply SMainMenuWidget::HandleStartClicked()
+{
+    if (StartClicked.IsBound())
+    {
+        StartClicked.Execute();
+    }
+    return FReply::Handled();
+}
+
+FReply SMainMenuWidget::HandleQuitClicked()
+{
+    if (QuitClicked.IsBound())
+    {
+        QuitClicked.Execute();
+    }
+    return FReply::Handled();
+}
+
+END_SLATE_FUNCTION_BUILD_OPTIMIZATION

--- a/Source/Defence/SMainMenuWidget.h
+++ b/Source/Defence/SMainMenuWidget.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "Widgets/SCompoundWidget.h"
+
+/** Simple Slate widget for the main menu */
+class SMainMenuWidget : public SCompoundWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SMainMenuWidget){}
+        SLATE_EVENT(FSimpleDelegate, OnStartClicked)
+        SLATE_EVENT(FSimpleDelegate, OnQuitClicked)
+    SLATE_END_ARGS()
+
+    void Construct(const FArguments& InArgs);
+
+private:
+    FSimpleDelegate StartClicked;
+    FSimpleDelegate QuitClicked;
+
+    FReply HandleStartClicked();
+    FReply HandleQuitClicked();
+};


### PR DESCRIPTION
## Summary
- add Slate widget `SMainMenuWidget`
- add UMG wrapper `UMainMenuWidget`
- create `AMenuGameMode` that displays the menu
- enable Slate modules in build rules

## Testing
- `ls -R | head`

------
https://chatgpt.com/codex/tasks/task_e_68422f5271088333a0c66382dda26ae6